### PR TITLE
Use log.warn instead log.error

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -135,8 +135,8 @@ function print_fallback_error(err,opts,package_json) {
     var full_message = "Pre-built binaries not found for " + package_json.name + "@" + package_json.version;
     full_message += " and " + opts.runtime + "@" + (opts.target || process.versions.node) + " (" + opts.node_abi + " ABI)";
     full_message += fallback_message;
-    log.error("Tried to download(" + err.statusCode + "): " + opts.hosted_tarball);
-    log.error(full_message);
+    log.warn("Tried to download(" + err.statusCode + "): " + opts.hosted_tarball);
+    log.warn(full_message);
     log.http(err.message);
 }
 


### PR DESCRIPTION
Since it is fallback maybe it would be better to use logger.warn - Some CI tools like TeamCity will assume that as failed build